### PR TITLE
Add support for compose multiplatform indexed args

### DIFF
--- a/plugin-build/buildSrc/src/main/java/Coordinates.kt
+++ b/plugin-build/buildSrc/src/main/java/Coordinates.kt
@@ -1,7 +1,7 @@
 object PluginCoordinates {
     const val ID = "io.github.jonathanimperato.loco-sync"
     const val GROUP = "io.github.jonathanimperato"
-    const val VERSION = "0.0.24"
+    const val VERSION = "0.0.25"
     const val IMPLEMENTATION_CLASS = "io.github.jonathanimperato.loco.sync.LocoSyncPlugin"
 }
 

--- a/plugin-build/plugin/src/main/java/io/github/jonathanimperato/loco/sync/GenerateResourcesTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/jonathanimperato/loco/sync/GenerateResourcesTask.kt
@@ -61,7 +61,7 @@ abstract class GenerateResourcesTask : DefaultTask() {
     }
     
     fun String.addIndexToArgs(): String {
-        return this.replace("%s", "%1$s") 
-            .replace("%d", "%1$d")        
+        return this.replace("%s", "%1\$s") 
+            .replace("%d", "%1\$d")        
     }
 }

--- a/plugin-build/plugin/src/main/java/io/github/jonathanimperato/loco/sync/GenerateResourcesTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/jonathanimperato/loco/sync/GenerateResourcesTask.kt
@@ -47,7 +47,7 @@ abstract class GenerateResourcesTask : DefaultTask() {
                     if (!directory.exists()) directory.mkdir()
                     val file = File(directory.absolutePath + "/" + config.fileName + ".xml")
                     val textContent = inputStream.bufferedReader().readText()
-                    file.writeText(if (unescape) textContent.unescapeXml() else textContent, Charsets.UTF_8)
+                    file.writeText(if (unescape) textContent.unescapeXml().addIndexToArgs() else textContent, Charsets.UTF_8)
                 }
             }
         }
@@ -58,5 +58,10 @@ abstract class GenerateResourcesTask : DefaultTask() {
     fun String.unescapeXml(): String {
         return this.replace("\\\\", "\\") // Rimuove i doppi backslash
             .replace("\\'", "'")         // Rimuove l'escape dal carattere singolo
+    }
+    
+    fun String.addIndexToArgs(): String {
+        return this.replace("%s", "%1$s") 
+            .replace("%d", "%1$d")        
     }
 }


### PR DESCRIPTION
In compose multiplatform, you cannot use %s and %d anymore to include args on strings, you need to add the index (that in Android you needed to specify only with multiple args) This implementation fixes it.
